### PR TITLE
Fix settings, improve include/exclude logic, and inform the user about wear when its prohibitive.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -33,7 +33,7 @@ minetest.register_on_mods_loaded(function()
       local allow_all   = minetest.settings:get_bool("allow_all", false)
       -- Initialize tool whitelist with registered tools
       for name, def in pairs(minetest.registered_tools) do
-	 table.insert(rTools, name)
+          rTools[def.name] = true
       end
       
       -- Initialize whitelist for registered nodes
@@ -48,48 +48,41 @@ minetest.register_on_mods_loaded(function()
 	    for name, def in pairs(minetest.registered_ores) do
 	       local node_name = def.ore
 	       if string.find(node_name, "stone_with_") ~= nil then
-		  table.insert(rNodes, node_name)
+               rNodes[node_name] = true
 	       end
 	    end
 	 end
 
 	 -- Register tree nodes
-	 if allow_trees then
-	    for name, def in pairs(minetest.registered_nodes) do
-	       if def.groups.tree ~= nil then
-		  local node_name = def.name
-		  table.insert(rNodes, node_name)
-	       end
-	    end
-	 end
+	if allow_trees then
+		for name, def in pairs(minetest.registered_nodes) do
+			if def.groups.tree ~= nil then
+				local node_name = def.name
+				rNodes[node_name] = true
+			end
+		end
+	end
       end
 end)
 
 
 local function is_node_vein_diggable(nodeName, wieldedName)
-   local nodeCheck = nodeBlacklist
-   local toolCheck = toolBlacklist
-   -- check nodes
-   for k, v in pairs(rNodes) do
-      if v == nodeName and nodeBlacklist == true then
-	 nodeCheck = false
-      elseif v == nodeName and nodeBlacklist == false then
-	 nodeCheck = true	
-      end
-   end
+    local nodeCheck = nodeBlacklist and true or false
+    local toolCheck = toolBlacklist and true or false
 
-   -- return false if nodeCheck failed
-   --if nodeCheck == false then return false end	
-   
-   for k, v in pairs(rTools) do
-      if v == wieldedName and toolBlacklist == true then
-	 toolCheck = false
-      elseif v == wieldedName and toolBlacklist == false then
-	 toolCheck = true	
-      end
-   end
-   
-   return nodeCheck and toolCheck
+    -- check nodes
+    if next(rNodes) then
+        local isNodeInRnodes = (rNodes[nodeName] ~= nil) and true or false
+        nodeCheck = (isNodeInRnodes ~= nodeBlacklist)
+    end
+
+    -- check tools
+    if next(rTools) then
+        local isToolInRtools = (rTools[wieldedName] ~= nil) and true or false
+        toolCheck = (isToolInRtools ~= toolBlacklist)
+    end
+
+    return nodeCheck and toolCheck
 end
 
 -- Recursively mines a vein of blocks

--- a/init.lua
+++ b/init.lua
@@ -2,6 +2,9 @@ vein_miner = {
    deque = {}
 }
 dofile(minetest.get_modpath("vein_miner") .. "/deque.lua")
+
+local S = minetest.get_translator("vein_miner")
+
 -- Maximum number of nodes that can be vein mined at once
 local MAX_MINED_NODES = 188
 
@@ -109,9 +112,13 @@ local function dig_pos(pos, oldnode, center, digger)
    local wear_limit = 65535 - dp.wear
    local mined_nodes = 0
    
+   if wielded:get_wear() >= wear_limit then
+       minetest.chat_send_player(digger:get_player_name(), S("Tool does not have enough durability to mine this vein"))
+   end
+
    -- add pos to queue
    queue:push_right(pos)
-   while not queue:is_empty() and wielded:get_wear() < 65535 - dp.wear and mined_nodes < MAX_MINED_NODES do
+   while not queue:is_empty() and wielded:get_wear() < wear_limit and mined_nodes < MAX_MINED_NODES do
       -- Pop left-most item
       local pos = queue:pop_left()
       -- Find adjacent nodes to dug node

--- a/init.lua
+++ b/init.lua
@@ -28,10 +28,9 @@ minetest.register_on_mods_loaded(function()
 	 MAX_MINED_NODES = 188
       end
       
-      local stringtoboolean = { ["true"]=true, ["false"]=false }
-      local allow_ores = stringtoboolean[minetest.settings:get("allow_ores")]
-      local allow_trees = stringtoboolean[minetest.settings:get("allow_trees")]
-      local allow_all = stringtoboolean[minetest.settings:get("allow_all")]
+      local allow_ores  = minetest.settings:get_bool("allow_ores", true)
+      local allow_trees = minetest.settings:get_bool("allow_trees", true)
+      local allow_all   = minetest.settings:get_bool("allow_all", false)
       -- Initialize tool whitelist with registered tools
       for name, def in pairs(minetest.registered_tools) do
 	 table.insert(rTools, name)


### PR DESCRIPTION
What this pull request does:
- First commit fixes #10 ; method of retrieving settings was causing vein mining to not work for new users because everything was false when not present in minetest.conf. Would have been invisible to older users as their settings would be present.
- Second commit improves the include/exclude logic from O(n) to O(log2(n)); so my world with 32k registered nodes can do vein mining with 16 checks instead of 32k checks every time someone vein mines. Should make it more server friendly.
- Third commit is a usability commit; informs the user when vein mining cannot occur due to tool wear.

Notes
- Variables and code style was kept in-line with what I saw; 
- all code I added use tabs; the code in general uses an odd combination of spaces and tabs within the same line. 
  - I recommend correcting this.

Just in case it's desirable to prove the speed improvement, I've created the following snippit which may be added to the end of init.lua ; one can look at the timestamps to see the difference. On my desktop machine (fairly beefy) the original technique where the collection is scanned item-by-item takes 10 seconds, the second technique is sub-second. 

```
local val = {}
  local val_to_lookup = {}
  for idx=1,65534 do
      val[idx] = idx
      val_to_lookup[idx] = math.random(1,65534)
  end

  minetest.log("error", "Starting scan no keys")
  for key_to_search,_ in pairs(val_to_lookup) do
      local cnt = 0
      for k, v in pairs(val) do
          if v == key_to_search then
              break
          end
      end
  end
  minetest.log("error", "Finished scanning no keys in ")

  minetest.log("error", "Starting scan with keys")
  for key_to_search, _ in pairs(val_to_lookup) do
      local cnt = 0

      if val[key_to_search] ~= nil then
          -- found
          goto continue
      end

      ::continue::
  end

  minetest.log("error", "Finished scan with keys")
  ``` 
