### PR TITLE
Namespaces

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -27,7 +27,7 @@ minetest.register_on_mods_loaded(
 	
 	-- Check legacy settings
         local allow_ores = minetest.settings:get_bool("allow_ores", true)
-        local allow_trees = minetest.settings:get_bool("allow_trees", true)
+        local allow_trees = minetest.settings:get_bool("allow_trees", false)
         local allow_all = minetest.settings:get_bool("allow_all", false)
 	
         -- Fetch settings
@@ -44,7 +44,7 @@ minetest.register_on_mods_loaded(
         end
 
 	if allow_trees == nil then
-	   local allow_trees = minetest.settings:get_bool("allow_trees", true)
+	   local allow_trees = minetest.settings:get_bool("allow_trees", false)
 	end
 
 	if allow_all == nil then

--- a/init.lua
+++ b/init.lua
@@ -44,11 +44,11 @@ minetest.register_on_mods_loaded(
         end
 
 	if allow_trees == nil then
-	   local allow_trees = minetest.settings:get_bool("allow_trees", false)
+	   local allow_trees = minetest.settings:get_bool("vein_miner_allow_trees", false)
 	end
 
 	if allow_all == nil then
-	   local allow_all = minetest.settings:get_bool("allow_all", false)
+	   local allow_all = minetest.settings:get_bool("vein_miner_allow_all", false)
 	end
 	
         -- Initialize tool whitelist with registered tools

--- a/init.lua
+++ b/init.lua
@@ -24,6 +24,12 @@ minetest.register_on_mods_loaded(
     function()
         -- Get settings
 
+	
+	-- Check legacy settings
+        local allow_ores = minetest.settings:get_bool("allow_ores", true)
+        local allow_trees = minetest.settings:get_bool("allow_trees", true)
+        local allow_all = minetest.settings:get_bool("allow_all", false)
+	
         -- Fetch settings
         MAX_MINED_NODES = tonumber(minetest.settings:get("vein_miner_max_nodes"))
 
@@ -32,9 +38,19 @@ minetest.register_on_mods_loaded(
             MAX_MINED_NODES = 188
         end
 
-        local allow_ores = minetest.settings:get_bool("allow_ores", true)
-        local allow_trees = minetest.settings:get_bool("allow_trees", true)
-        local allow_all = minetest.settings:get_bool("allow_all", false)
+	-- Use namespaces settings if legacy settings are unset
+	if allow_ores == nil then
+	   local allow_ores = minetest.settings:get_bool("vein_miner_allow_ores", true)   
+        end
+
+	if allow_trees == nil then
+	   local allow_trees = minetest.settings:get_bool("allow_trees", true)
+	end
+
+	if allow_all == nil then
+	   local allow_all = minetest.settings:get_bool("allow_all", false)
+	end
+	
         -- Initialize tool whitelist with registered tools
         for name, def in pairs(minetest.registered_tools) do
             rTools[def.name] = true

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -2,10 +2,10 @@
 vein_miner_max_nodes (Maximum Mineable Nodes) int 188
 
 # If true, allows vein mining of "stone_with_[orename]" blocks
-allow_ores (Allow mining ores) bool true
+vein_miner_allow_ores (Allow mining ores) bool true
 
 # If true, allows vein mining tree blocks (logs, leaves, ect.)
-allow_trees (Allow mining trees) bool true
+vein_miner_allow_trees (Allow mining trees) bool true
 
 # If true, allow vein mining any block. Overrides previous settings
-allow_all (Allow mining any node) bool false
+vein_miner_allow_all (Allow mining any node) bool false

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -5,7 +5,7 @@ vein_miner_max_nodes (Maximum Mineable Nodes) int 188
 vein_miner_allow_ores (Allow mining ores) bool true
 
 # If true, allows vein mining tree blocks (logs, leaves, ect.)
-vein_miner_allow_trees (Allow mining trees) bool true
+vein_miner_allow_trees (Allow mining trees) bool false
 
 # If true, allow vein mining any block. Overrides previous settings
 vein_miner_allow_all (Allow mining any node) bool false


### PR DESCRIPTION
Changes technical setting names to use the mod namespace, improving compatibility and resolving #12.

Also changes the default setting for chopping trees to false, which makes it easier to use other tree chopping mods by default.